### PR TITLE
fix scale between subtitle and video on CWord

### DIFF
--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -138,12 +138,14 @@ CMyFont::CMyFont(const STSStyleBase& style)
 // CWord
 
 CWord::CWord( const FwSTSStyle& style, const CStringW& str, int ktype, int kstart, int kend
+    , double scalex, double scaley
     , double target_scale_x/*=1.0*/, double target_scale_y/*=1.0*/
     , bool round_to_whole_pixel_after_scale_to_target/*=false*/)
     : m_style(style), m_str(DEBUG_NEW CStringW(str))
     , m_width(0), m_ascent(0), m_descent(0)
     , m_ktype(ktype), m_kstart(kstart), m_kend(kend)
     , m_fLineBreak(false), m_fWhiteSpaceChar(false)
+    , m_scalex(scalex), m_scaley(scaley)
     , m_target_scale_x(target_scale_x), m_target_scale_y(target_scale_y)
     , m_round_to_whole_pixel_after_scale_to_target(round_to_whole_pixel_after_scale_to_target)
     //, m_pOpaqueBox(NULL)
@@ -167,6 +169,8 @@ CWord::CWord( const CWord& src):m_str(src.m_str)
     m_width                                      = src.m_width;
     m_ascent                                     = src.m_ascent;
     m_descent                                    = src.m_descent;
+    m_scalex = src.m_scalex;
+    m_scaley = src.m_scaley;
     m_target_scale_x                             = src.m_target_scale_x;
     m_target_scale_y                             = src.m_target_scale_y;
     m_round_to_whole_pixel_after_scale_to_target = src.m_round_to_whole_pixel_after_scale_to_target;
@@ -510,37 +514,39 @@ void CWord::Transform(PathData* path_data, const CPointCoor2 &org )
 
     //S0*A0*A1*A2*A3*A4
 
-    tmp1 = 20000.0*m_target_scale_x;
+    tmp1 = 20000.0 * m_scalex * m_target_scale_x;
     xxx[0][0] *= tmp1;
     xxx[0][1] *= tmp1;
     xxx[0][2] *= tmp1;
 
-    tmp1 = 20000.0*m_target_scale_y;
+    tmp1 = 20000.0 * m_scaley * m_target_scale_y;
     xxx[1][0] *= tmp1;
     xxx[1][1] *= tmp1;
     xxx[1][2] *= tmp1;
 
     //A0*A1*A2*A3*A4+B0
 
-    xxx[2][2] += 20000.0;
+    //xxx[2][2] += 20000.0;
 
     double scaled_org_x = org.x+0.5;
     double scaled_org_y = org.y+0.5;
 
     for (ptrdiff_t i = 0; i < path_data->mPathPoints; i++) {
-        double x, y, z, xx;
+        double x, y, zx, zy, xx;
 
         xx = path_data->mpPathPoints[i].x;
         y = path_data->mpPathPoints[i].y;
 
-        z = xxx[2][0] * xx + xxx[2][1] * y + xxx[2][2];
+        zx = xxx[2][0] * xx + xxx[2][1] * y + xxx[2][2] + 20000.0 * m_scalex;
+        zy = xxx[2][0] * xx + xxx[2][1] * y + xxx[2][2] + 20000.0 * m_scaley;
         x = xxx[0][0] * xx + xxx[0][1] * y + xxx[0][2];
         y = xxx[1][0] * xx + xxx[1][1] * y + xxx[1][2];
 
-        z = z > 1000.0 ? z : 1000.0;
+        zx = zx > 1000.0 ? zx : 1000.0;
+        zy = zy > 1000.0 ? zy : 1000.0;
 
-        x = x / z;
-        y = y / z;
+        x = x / zx;
+        y = y / zy;
 
         path_data->mpPathPoints[i].x = (long)(x + scaled_org_x);
         path_data->mpPathPoints[i].y = (long)(y + scaled_org_y);
@@ -594,8 +600,9 @@ bool CWord::operator==( const CWord& rhs ) const
 // CText
 
 CText::CText( const FwSTSStyle& style, const CStringW& str, int ktype, int kstart, int kend
+    , double scalex, double scaley
     , double target_scale_x/*=1.0*/, double target_scale_y/*=1.0*/ )
-    : CWord(style, str, ktype, kstart, kend, target_scale_x, target_scale_y)
+    : CWord(style, str, ktype, kstart, kend, scalex, scaley, target_scale_x, target_scale_y)
 {
     if(m_str.Get() == L" ")
     {
@@ -727,8 +734,8 @@ CPolygon::CPolygon( const FwSTSStyle& style, const CStringW& str, int ktype, int
     , double scalex, double scaley, int baseline 
     , double target_scale_x/*=1.0*/, double target_scale_y/*=1.0*/
     , bool round_to_whole_pixel_after_scale_to_target/*=false*/)
-    : CWord(style, str, ktype, kstart, kend, target_scale_x, target_scale_y, round_to_whole_pixel_after_scale_to_target)
-    , m_scalex(scalex), m_scaley(scaley), m_baseline(baseline)
+    : CWord(style, str, ktype, kstart, kend, scalex, scaley, target_scale_x, target_scale_y, round_to_whole_pixel_after_scale_to_target)
+    , m_baseline(baseline)
 {
     ParseStr();
 }
@@ -1973,6 +1980,7 @@ void CRenderedTextSubtitle::ParseString(CSubtitle* sub, CStringW str, const FwST
         if(ite < j)
         {
             if(PCWord tmp_ptr = DEBUG_NEW CText(style, str.Mid(ite, j-ite), m_ktype, m_kstart, m_kend
+                , sub->m_scalex, sub->m_scaley
                 , m_target_scale_x, m_target_scale_y))
             {
                 SharedPtrCWord w(tmp_ptr);
@@ -1987,6 +1995,7 @@ void CRenderedTextSubtitle::ParseString(CSubtitle* sub, CStringW str, const FwST
         if(c == L'\n')
         {
             if(PCWord tmp_ptr = DEBUG_NEW CText(style, CStringW(), m_ktype, m_kstart, m_kend
+                , sub->m_scalex, sub->m_scaley
                 , m_target_scale_x, m_target_scale_y))
             {
                 SharedPtrCWord w(tmp_ptr);
@@ -2001,6 +2010,7 @@ void CRenderedTextSubtitle::ParseString(CSubtitle* sub, CStringW str, const FwST
         else if(c == L' ')
         {
             if(PCWord tmp_ptr = DEBUG_NEW CText(style, CStringW(c), m_ktype, m_kstart, m_kend
+                , sub->m_scalex, sub->m_scaley
                 , m_target_scale_x, m_target_scale_y))
             {
                 SharedPtrCWord w(tmp_ptr);

--- a/src/subtitles/RTS.h
+++ b/src/subtitles/RTS.h
@@ -96,6 +96,7 @@ protected:
 public:
     // str[0] = 0 -> m_fLineBreak = true (in this case we only need and use the height of m_font from the whole class)
     CWord(const FwSTSStyle& style, const CStringW& str, int ktype, int kstart, int kend
+        , double scalex, double scaley
         , double target_scale_x=1.0, double target_scale_y=1.0
         , bool round_to_whole_pixel_after_scale_to_target = false);
     CWord(const CWord&);
@@ -120,6 +121,7 @@ public:
     SharedPtrCPolygon m_pOpaqueBox;
     int               m_ktype, m_kstart, m_kend;
     int               m_width, m_ascent, m_descent;
+    double            m_scalex, m_scaley;
     double            m_target_scale_x, m_target_scale_y;
     bool              m_round_to_whole_pixel_after_scale_to_target;//it is necessary to avoid some artifacts
 
@@ -146,6 +148,7 @@ protected:
     static void GetTextInfo(TextInfo *output, const FwSTSStyle& style, const CStringW& str);
 public:
     CText(const FwSTSStyle& style, const CStringW& str, int ktype, int kstart, int kend
+        , double scalex, double scaley
         , double target_scale_x=1.0, double target_scale_y=1.0);
     CText(const CText& src);
 
@@ -160,7 +163,6 @@ class CPolygon : public CWord
     bool ParseStr();
 
 protected:
-    double            m_scalex, m_scaley;
     int               m_baseline;
     CAtlArray<BYTE>   m_pathTypesOrg;
     CAtlArray<CPoint> m_pathPointsOrg;


### PR DESCRIPTION
xy-VSFilter has two scales, scale* handles scale between subtitle and video, target_scale_* handles scale between video and output rect.
This PR means to handle scale* on CWord, which is mainly used on function Transform, and fix #1 .